### PR TITLE
[WIP] Support for Windows ( bfirsh/whalebrew#29 )

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: go
 go:
-- 1.7
+- master
+
+# For forked project
+before_install:
+- mkdir -p $HOME/gopath/src/github.com/bfirsh/whalebrew
+- rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/bfirsh/whalebrew/
+- export TRAVIS_BUILD_DIR=$HOME/gopath/src/github.com/bfirsh/whalebrew
+- cd $HOME/gopath/src/github.com/bfirsh/whalebrew
+
 install:
 - go get -t ./...
 - go get github.com/golang/lint/golint
@@ -15,6 +23,7 @@ deploy:
   provider: releases
   api_key:
     secure: PvRBdjIyAzq+x8Sq0lJW+wRqE+kUE6t+FDxIpawmaUWLvJmA5R1n8RiHMniYTQFOE/0I8SaKu6TbzvnlIZBqG9DIvi3o/eu6mJJCh1tXQHCzo+sfbLtm6545svKUtLTzGF4jESWsKE5x43DgjMCboPKuE4Y7iLs6x7/n6qDgOffZyFkJCPEQd595D7O8LTtL3eHuvzXnxzDIcohSbe1z/YN7b/R4SvT04yXVrji5WmEcuueqQiq/z2BaCh8+TUBihApw024ICCWjALgWQF3XBYnWgW6TR8RQzJB+uA16VjWPetFpPiyOGX824fhUU9u9UoEQyJOQ0BvtI3qTP+2m7VWWKnZuLBxQ68H2o3U/qufrnklVXnargem1455Dq0wVXxwYbTANZcHx0rEzIhcQeAwhMiHFKAGQMpEOqvSC0A2m1RbO4K/LjBNLu6Ab+HfIzgdecRP78U79NVPGVX7PZijxPlvhMYk4z+J20kH65yRZUZoRSqmT/AwMlmdOUEbPjqIsBGinfydWspUfUNf85uDsIfONznTd/X148Pj78CPV5mew9zdx4Jjc9FwYmSyO2zUYpsBJfsF5KMgU3E8SQuKj9s0wwvGAAOTcQMufe9U3bJkq/AxwQOq9CiuNAGTpm1NYZFEuRRCyvnVZ/DJiE6hp4Q98koIzI2p0lpRH+/0=
+  skip_cleanup: true
   file:
   - "build/whalebrew-Darwin-x86_64"
   - "build/whalebrew-Linux-x86_64"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Docker works well for packaging up development environments, but there are lots 
 Whalebrew can run almost any CLI tool, but it isn't for everything (e.g. where commands must start instantly). It works particularly well for:
 
 * **Complex dependencies.** For example, a Python app that requires C libraries, specific package versions, and other CLI tools that you don't want to clutter up your machine with.
-* **Cross-platform portability.** Package managers tend to be very closely tied to the system they are running on. Whalebrew packages work on any modern version of macOS, Linux, and Windows (coming soon).
+* **Cross-platform portability.** Package managers tend to be very closely tied to the system they are running on. Whalebrew packages work on any modern version of macOS, Linux, and Windows.
 
 ## Install
 
@@ -44,7 +44,13 @@ Next, on macOS and Linux:
 
     curl -L "https://github.com/bfirsh/whalebrew/releases/download/0.1.0/whalebrew-$(uname -s)-$(uname -m)" -o /usr/local/bin/whalebrew; chmod +x /usr/local/bin/whalebrew
 
-Windows support is theoretically possible, but not implemented yet.
+on Windows with Command Prompt:
+
+    @"%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "Set-ExecutionPolicy -Scope CurrentUser Bypass; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/bfirsh/whalebrew/0.0.5/install.ps1'))" && SET "WHALEBREW_INSTALL_PATH=C:\whalebrew" && SET "PATH=%PATH%;%WHALEBREW_INSTALL_PATH%"
+
+on Windows with Powershell:
+
+    Set-ExecutionPolicy -Scope CurrentUser AllSigned; iex ((New-Object System.Net.WebClient).DownloadString('https://raw.githubusercontent.com/bfirsh/whalebrew/0.0.5/install.ps1'))
 
 ## Usage
 
@@ -94,7 +100,7 @@ To upgrade a single package, just pull its image:
 
 Whalebrew is configured with environment variables, which you can either provide at runtime or put in your `~/.bashrc` file (or whatever shell you use).
 
- - `WHALEBREW_INSTALL_PATH`: The directory to install packages in. (default: `/usr/local/bin`)
+ - `WHALEBREW_INSTALL_PATH`: The directory to install packages in. (default for macOS and Linux: `/usr/local/bin`, default for Windows: `C:\whalebrew`)
 
 ## How it works
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: "{build}"
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\gopath\src\github.com\bfirsh\whalebrew
+
+environment:
+  GOPATH: c:\gopath
+
+artifacts:
+  - path: build\*
+
+install:
+  - set PATH=%GOPATH%\bin;%PATH%
+  - git submodule update --init --recursive
+  - go version
+  - go env
+  - go get -t ./...
+  - go get -u github.com/golang/lint/golint
+  - go get -u github.com/mitchellh/gox
+
+build_script:
+  - golint ./...
+  - go test ./...
+  - ps: script/build-for-windows.ps1
+
+test: off
+
+deploy:
+  provider: GitHub
+  auth_token:
+    secure: ""
+  artifact: build\whalebrew-Windows-x86_64.exe
+  on:
+    appveyor_repo_tag: true

--- a/client/client.go
+++ b/client/client.go
@@ -1,11 +1,10 @@
 package client
 
 import (
+	"context"
+
 	"github.com/docker/docker/client"
 )
-
-// DefaultVersion is the Engine API version used by Whalebrew
-const DefaultVersion string = "1.20"
 
 // NewClient returns a Docker client configured for Whalebrew
 func NewClient() (*client.Client, error) {
@@ -13,6 +12,6 @@ func NewClient() (*client.Client, error) {
 	if err != nil {
 		return cli, err
 	}
-	cli.UpdateClientVersion(DefaultVersion)
+	cli.NegotiateAPIVersion(context.Background())
 	return cli, nil
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 
 	"github.com/Songmu/prompter"
 	"github.com/bfirsh/whalebrew/client"
@@ -91,7 +90,7 @@ var installCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Printf("🐳  Installed %s to %s\n", imageName, path.Join(pm.InstallPath, pkg.Name))
+		fmt.Printf("🐳  Installed %s to %s\n", imageName, pm.MakePackagePath(pkg.Name))
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"runtime"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -8,6 +10,9 @@ import (
 func init() {
 	viper.SetEnvPrefix("whalebrew")
 	viper.SetDefault("install_path", "/usr/local/bin")
+	if runtime.GOOS == "windows" {
+		viper.SetDefault("install_path", "C:\\whalebrew")
+	}
 	viper.BindEnv("install_path")
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"syscall"
 
+	"runtime"
+
 	"github.com/bfirsh/whalebrew/packages"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
@@ -70,9 +72,34 @@ var runCommand = &cobra.Command{
 			dockerArgs = append(dockerArgs, "-p")
 			dockerArgs = append(dockerArgs, portmap)
 		}
+
 		for _, network := range pkg.Networks {
 			dockerArgs = append(dockerArgs, "--net")
 			dockerArgs = append(dockerArgs, network)
+		}
+
+		if runtime.GOOS == "windows" {
+			dockerArgs = append(dockerArgs, pkg.Image)
+			dockerArgs = append(dockerArgs, args[1:]...)
+
+			dockerCmd := exec.Command(dockerPath, dockerArgs[1:]...)
+			dockerCmd.Env = os.Environ()
+			dockerCmd.Stdin = os.Stdin
+			dockerCmd.Stdout = os.Stdout
+			dockerCmd.Stderr = os.Stderr
+
+			exitStatus := 1
+			if err := dockerCmd.Run(); err != nil {
+				if exitError, ok := err.(*exec.ExitError); ok {
+					if ws, ok := exitError.Sys().(syscall.WaitStatus); ok {
+						exitStatus = ws.ExitStatus()
+					}
+				}
+			} else {
+				ws := dockerCmd.ProcessState.Sys().(syscall.WaitStatus)
+				exitStatus = ws.ExitStatus()
+			}
+			os.Exit(exitStatus)
 		}
 
 		user, err := user.Current()

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"path"
 
 	"github.com/Songmu/prompter"
 	"github.com/bfirsh/whalebrew/packages"
@@ -28,7 +27,7 @@ var uninstallCommand = &cobra.Command{
 		pm := packages.NewPackageManager(viper.GetString("install_path"))
 		packageName := args[0]
 
-		path := path.Join(pm.InstallPath, packageName)
+		path := pm.MakePackagePath(packageName)
 
 		if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
 			return nil

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,38 @@
+# Whalebrew Installer for Windows
+
+try {
+  $orgErrorActionPreference = $ErrorActionPreference
+  $ErrorActionPreference = "Stop"
+
+  $VERSION = "0.1.0"
+  $BINARY_URL = "https://github.com/3846masa/whalebrew/releases/download/$VERSION/whalebrew-Windows-x86_64.exe"
+  $USER_PATH = [Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::User)
+  $WHALEBREW_INSTALL_PATH = [Environment]::GetEnvironmentVariable("WHALEBREW_INSTALL_PATH", [System.EnvironmentVariableTarget]::User)
+
+  if ($WHALEBREW_INSTALL_PATH -eq $null -or $WHALEBREW_INSTALL_PATH -eq '') {
+    $WHALEBREW_INSTALL_PATH = 'C:\whalebrew';
+    [Environment]::SetEnvironmentVariable("WHALEBREW_INSTALL_PATH", $WHALEBREW_INSTALL_PATH, [System.EnvironmentVariableTarget]::User)
+  }
+
+  if (![System.IO.Directory]::Exists($WHALEBREW_INSTALL_PATH)) {
+    [System.IO.Directory]::CreateDirectory($WHALEBREW_INSTALL_PATH)
+  }
+
+  if ($($USER_PATH).ToLower().Contains($($WHALEBREW_INSTALL_PATH).ToLower()) -eq $false) {
+    [Environment]::SetEnvironmentVariable("Path", "$USER_PATH;%WHALEBREW_INSTALL_PATH%", [System.EnvironmentVariableTarget]::User)
+  }
+
+  Write-Output "`nDownloading Whalebrew from : $BINARY_URL"
+
+  $WHALEBREW_PATH = Join-Path $WHALEBREW_INSTALL_PATH "whalebrew.exe"
+  (New-Object System.Net.WebClient).DownloadFile($BINARY_URL, "$WHALEBREW_PATH")
+
+  Write-Output "`nInstalled whalebrew to `"$WHALEBREW_PATH`"`n"
+}
+catch {
+  $Host.UI.WriteErrorLine("`nFailed to install whalebrew...`n")
+  Write-Error $error[1]
+}
+finally {
+  $ErrorActionPreference = $orgErrorActionPreference
+}

--- a/script/build
+++ b/script/build
@@ -4,6 +4,7 @@ set -e
 
 mkdir -p build
 cd build
+
 gox -osarch="linux/amd64" -osarch="darwin/amd64" ../
 
 mv whalebrew_linux_amd64 whalebrew-Linux-x86_64

--- a/script/build-for-windows.ps1
+++ b/script/build-for-windows.ps1
@@ -1,0 +1,6 @@
+New-Item -ItemType Directory -Path ./build
+Set-Location ./build
+
+gox -osarch="windows/amd64" ../
+
+Move-Item whalebrew_windows_amd64.exe whalebrew-Windows-x86_64.exe


### PR DESCRIPTION
Whalebrew on Windows 🐋 🎉 🐳  ( bfirsh/whalebrew#29 )

I checked on cmd and MSYS2 bash with Docker for Windows.

---

# PR for Windows

## syscall -> exec (https://github.com/3846masa/whalebrew/commit/8a6d78379dbc0357fa95679ce10c8f5db24d8301)
To change `syscall.Exec` to `exec.Command` because `syscall.Exec` causes Error on Windows.

## ~Fix checking args~
~First argument checking hack is not working on Windows. I changed it.~

## Add batch file support (https://github.com/3846masa/whalebrew/commit/ffbdd151865b700478a742c31f1af16d783666ed)
When `whalebrew install` on Windows, generate batch file.
~Batch file passes shell file and args to `whalebrew`.~

## Fix default WHALEBREW_INSTALL_PATH (https://github.com/3846masa/whalebrew/commit/74db526e3efce7250e19cc1d85683e394034fa69)
I have no idea where is good for install_path on Windows.
Temporally, `WHALEBREW_INSTALL_PATH` is `C:\whalebrew` if on Windows.

### Add install script for Windows (https://github.com/3846masa/whalebrew/commit/94a625d808d9fb4d9f11ea996e70bc427026c926)
Install script will download `whalebrew.exe` and set `Path` and `WHALEBREW_INSTALL_PATH`.

## `path.Join` -> `filepath.Join` (https://github.com/3846masa/whalebrew/commit/7453d3797a457968005073a74a502dda3e9638ca)
c.f. ) http://stackoverflow.com/questions/9371031/how-do-i-create-crossplatform-file-paths-in-go

## Rewrite test for Windows (https://github.com/3846masa/whalebrew/commit/bc12aa0da1b47f5d6f0a608c348423ad6ca50767)

### Add `MakePackagePath` function (https://github.com/3846masa/whalebrew/commit/fe06f35661c97bd768341767ae9e9e2b71d252f4)
Because package file name is different on Windows and *nix

---

# TODO

- [x] CI Test for Windows
- [x] Best solution for `WHALEBREW_INSTALL_PATH` on Windows

---

This is first time to write golang. Please check changes. 🙏 
Thanks.