### PR TITLE
Add Support for custom entrypoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7
+- 1.11
 install:
 - go get -t ./...
 - go get github.com/golang/lint/golint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.11
 
 RUN mkdir -p /go/src/github.com/bfirsh/whalebrew
 WORKDIR /go/src/github.com/bfirsh/whalebrew

--- a/client/client.go
+++ b/client/client.go
@@ -9,7 +9,12 @@ const DefaultVersion string = "1.20"
 
 // NewClient returns a Docker client configured for Whalebrew
 func NewClient() (*client.Client, error) {
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.WithVersion("1.39"))
+	if err != nil {
+		return cli, err
+	}
+
+	err = client.FromEnv(cli)
 	if err != nil {
 		return cli, err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -13,6 +13,6 @@ func NewClient() (*client.Client, error) {
 	if err != nil {
 		return cli, err
 	}
-	cli.UpdateClientVersion(DefaultVersion)
+
 	return cli, nil
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -16,6 +16,7 @@ import (
 )
 
 var customPackageName string
+var entrypoint string
 var forceInstall bool
 var assumeYes bool
 
@@ -23,6 +24,7 @@ func init() {
 	installCommand.Flags().StringVarP(&customPackageName, "name", "n", "", "Name to give installed package. Defaults to image name.")
 	installCommand.Flags().BoolVarP(&forceInstall, "force", "f", false, "Replace existing package if already exists. Defaults to false.")
 	installCommand.Flags().BoolVarP(&assumeYes, "assume-yes", "y", false, "Assume 'yes' as answer to all prompts and run non-interactively. Defaults to false.")
+	installCommand.Flags().StringVarP(&entrypoint, "entrypoint", "e", "", "Override the entrypoint defined in the image. Defaults to image's entrypoint")
 
 	RootCmd.AddCommand(installCommand)
 }
@@ -70,6 +72,9 @@ var installCommand = &cobra.Command{
 		}
 		if customPackageName != "" {
 			pkg.Name = customPackageName
+		}
+		if entrypoint != "" {
+			pkg.Entrypoint = entrypoint
 		}
 
 		preinstallMessage := pkg.PreinstallMessage()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -14,6 +14,7 @@ import (
 )
 
 func init() {
+	runCommand.Flags().SetInterspersed(false)
 	runCommand.Flags().StringVarP(&entrypoint, "entrypoint", "e", "", "Override the entrypoint defined in the image. Defaults to image's entrypoint")
 
 	RootCmd.AddCommand(runCommand)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -97,7 +97,11 @@ var runCommand = &cobra.Command{
 		if entrypoint != "" {
 			dockerArgs = append(dockerArgs, "--entrypoint")
 			dockerArgs = append(dockerArgs, entrypoint)
+		} else if pkg.Entrypoint != "" {
+			dockerArgs = append(dockerArgs, "--entrypoint")
+			dockerArgs = append(dockerArgs, pkg.Entrypoint)
 		}
+
 		dockerArgs = append(dockerArgs, pkg.Image)
 		dockerArgs = append(dockerArgs, cmdArgs...)
 

--- a/packages/package.go
+++ b/packages/package.go
@@ -20,6 +20,7 @@ type Package struct {
 	Ports       []string `yaml:"ports,omitempty"`
 	Networks    []string `yaml:"networks,omitempty"`
 	WorkingDir  string   `yaml:"working_dir,omitempty"`
+	Entrypoint  string   `yaml:"entrypoint,omitempty"`
 }
 
 // NewPackageFromImage creates a package from a given image name,

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version is the current Whalebrew version
-const Version = "0.1.0"
+const Version = "0.1.2"


### PR DESCRIPTION
Hi, I think in some cases it is useful to run the whalebrew package with custom entrypoint. For example, instead of running the target command directly, sometimes it is necessary to access shell and execute the target command within the docker shell. This PR add the following support:

```
whalebrew run --entrypoint=/bin/sh $(which jq)
```