### PR TITLE
Add configuration to keep container user

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ There are some labels you can use to configure how Whalebrew installs your image
 
         LABEL io.whalebrew.config.working_dir '/working_directory'
 
+* `io.whalebrew.config.keep_container_user`: Set this variable to true to keep the default container USER. When set to true, whalebrew will not run the command as the current user using the docker `-u` flag
+
+        LABEL io.whalebrew.config.keep_container_user 'true'
+
+
 #### Using user environment variables
 
 The labels `io.whalebrew.config.working_dir`, `io.whalebrew.config.volumes` and `io.whalebrew.config.environment` are expanded with user environment variables when the container is launched.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,12 +76,14 @@ var runCommand = &cobra.Command{
 			dockerArgs = append(dockerArgs, network)
 		}
 
-		user, err := user.Current()
-		if err != nil {
-			return err
+		if !pkg.KeepContainerUser {
+			user, err := user.Current()
+			if err != nil {
+				return err
+			}
+			dockerArgs = append(dockerArgs, "-u")
+			dockerArgs = append(dockerArgs, user.Uid+":"+user.Gid)
 		}
-		dockerArgs = append(dockerArgs, "-u")
-		dockerArgs = append(dockerArgs, user.Uid+":"+user.Gid)
 
 		dockerArgs = append(dockerArgs, pkg.Image)
 		dockerArgs = append(dockerArgs, args[1:]...)

--- a/packages/package.go
+++ b/packages/package.go
@@ -13,13 +13,14 @@ import (
 
 // Package represents a Whalebrew package
 type Package struct {
-	Name        string   `yaml:"-"`
-	Environment []string `yaml:"environment,omitempty"`
-	Image       string   `yaml:"image"`
-	Volumes     []string `yaml:"volumes,omitempty"`
-	Ports       []string `yaml:"ports,omitempty"`
-	Networks    []string `yaml:"networks,omitempty"`
-	WorkingDir  string   `yaml:"working_dir,omitempty"`
+	Name              string   `yaml:"-"`
+	Environment       []string `yaml:"environment,omitempty"`
+	Image             string   `yaml:"image"`
+	Volumes           []string `yaml:"volumes,omitempty"`
+	Ports             []string `yaml:"ports,omitempty"`
+	Networks          []string `yaml:"networks,omitempty"`
+	WorkingDir        string   `yaml:"working_dir,omitempty"`
+	KeepContainerUser bool     `yaml:"keep_container_user,omitempty"`
 }
 
 // NewPackageFromImage creates a package from a given image name,
@@ -74,6 +75,12 @@ func NewPackageFromImage(image string, imageInspect types.ImageInspect) (*Packag
 
 			if networks, ok := labels["io.whalebrew.config.networks"]; ok {
 				if err := yaml.Unmarshal([]byte(networks), &pkg.Networks); err != nil {
+					return pkg, err
+				}
+			}
+
+			if v, ok := labels["io.whalebrew.config.keep_container_user"]; ok {
+				if err := yaml.Unmarshal([]byte(v), &pkg.KeepContainerUser); err != nil {
 					return pkg, err
 				}
 			}


### PR DESCRIPTION
Some images are built to be used with a specific user ID, leave the opportunity to keep this user ID when running the container.
Under mac OS, or when user [remap](https://docs.docker.com/v17.09/engine/security/userns-remap/) is enabled, user keeps benefitting the full access of newly created files.
This option is disabled by default