### PR TITLE
Update client creation interface.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -9,10 +9,5 @@ const DefaultVersion string = "1.20"
 
 // NewClient returns a Docker client configured for Whalebrew
 func NewClient() (*client.Client, error) {
-	cli, err := client.NewEnvClient()
-	if err != nil {
-		return cli, err
-	}
-	cli.UpdateClientVersion(DefaultVersion)
-	return cli, nil
+	return client.NewClientWithOpts(client.WithVersion(DefaultVersion), client.FromEnv)
 }


### PR DESCRIPTION
The latest docker client interface does not have any UpdateClientVersion any longer since https://github.com/moby/moby/commit/5f1d94e569592fc2680f8661e16d0e5b02e82492