### PR TITLE
Run package container with --init option

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,6 +46,7 @@ var runCommand = &cobra.Command{
 			"--rm",
 			"--workdir", os.ExpandEnv(pkg.WorkingDir),
 			"-v", fmt.Sprintf("%s:%s", cwd, os.ExpandEnv(pkg.WorkingDir)),
+			"--init",
 		}
 		if terminal.IsTerminal(int(os.Stdin.Fd())) {
 			dockerArgs = append(dockerArgs, "--tty")


### PR DESCRIPTION
With this PR, whalebrew package container will be run with `--init` option of `docker run` command.

/close #71 

---

whalebrew run command does not use --init option of docker run command
for running packages. Due to this, some packages need tiny init such as
dumb-init.