### PR TITLE
Add support for pre/post install hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ To upgrade a single package, just pull its image:
 Whalebrew is configured with environment variables, which you can either provide at runtime or put in your `~/.bashrc` file (or whatever shell you use).
 
  - `WHALEBREW_INSTALL_PATH`: The directory to install packages in. (default: `/usr/local/bin`)
+ - `WHALEBREW_CONFIG_DIR`: The directory to install packages in. (default: `~/.whalebrew`)
 
 ## How it works
 
@@ -155,21 +156,20 @@ For example, if your image has this line in your `Dockerfile`:
 
 At runtime, it will bind your working directory into the container at the same path and set it as the working directory.
 
-
 #### Using hooks
 
 In some cases, you might want to execute custom actions, like checking the integrity of the image or adding the whalebrew scripts to your whalebrew repository.
 To do so, whalebrew will call git-like hooks when handling installation/uninstallation of a package.
-Those hooks must be executable files located in `${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks`.
+Those hooks must be executable files located in `${WHALEBREW_CONFIG_DIR}/hooks`.
 
 Whalebrew supports the following hooks:
 
-|path & arguments|description|
+|command & arguments|description|
 |-|-|
-|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/pre-install ${DOCKER_IMAGE} ${EXECUTABLE_NAME}`|This hook is called before installing a package. Failure of this hook will fail the installation process|
-|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/post-install ${EXECUTABLE_NAME}`|This hook is called after a package is installed. Failure of this hook will fail the installation process, but the package is not uninstalled|
-|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/pre-uninstall ${EXECUTABLE_NAME}`|This hook is called before uninstalling a package. Failure of this hook will fail the uninstallation process|
-|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/post-uninstall ${EXECUTABLE_NAME}`|This hook is called after a package is uninstalled. Failure of this hook will fail the uninstallation process, but the package is not uninstalled|
+|`pre-install ${DOCKER_IMAGE} ${EXECUTABLE_NAME}`|This hook is called before installing a package. Failure of this hook will fail the installation process|
+|`post-install ${EXECUTABLE_NAME}`|This hook is called after a package is installed. Failure of this hook will fail the installation process, but the package is not uninstalled|
+|`pre-uninstall ${EXECUTABLE_NAME}`|This hook is called before uninstalling a package. Failure of this hook will fail the uninstallation process|
+|`post-uninstall ${EXECUTABLE_NAME}`|This hook is called after a package is uninstalled. Failure of this hook will fail the uninstallation process, but the package is not uninstalled|
 
 ### Whalebrew images
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To upgrade a single package, just pull its image:
 Whalebrew is configured with environment variables, which you can either provide at runtime or put in your `~/.bashrc` file (or whatever shell you use).
 
  - `WHALEBREW_INSTALL_PATH`: The directory to install packages in. (default: `/usr/local/bin`)
- - `WHALEBREW_CONFIG_DIR`: The directory to install packages in. (default: `~/.whalebrew`)
+ - `WHALEBREW_CONFIG_DIR`: The directory to store configuration in. (default: `~/.whalebrew`)
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -156,6 +156,21 @@ For example, if your image has this line in your `Dockerfile`:
 At runtime, it will bind your working directory into the container at the same path and set it as the working directory.
 
 
+#### Using hooks
+
+In some cases, you might want to execute custom actions, like checking the integrity of the image or adding the whalebrew scripts to your whalebrew repository.
+To do so, whalebrew will call git-like hooks when handling installation/uninstallation of a package.
+Those hooks must be executable files located in `${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks`.
+
+Whalebrew supports the following hooks:
+
+|path & arguments|description|
+|-|-|
+|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/pre-install ${DOCKER_IMAGE} ${EXECUTABLE_NAME}`|This hook is called before installing a package. Failure of this hook will fail the installation process|
+|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/post-install ${EXECUTABLE_NAME}`|This hook is called after a package is installed. Failure of this hook will fail the installation process, but the package is not uninstalled|
+|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/pre-uninstall ${EXECUTABLE_NAME}`|This hook is called before uninstalling a package. Failure of this hook will fail the uninstallation process|
+|`${WHALEBREW_INSTALL_PATH}/.whalebrew/hooks/post-uninstall ${EXECUTABLE_NAME}`|This hook is called after a package is uninstalled. Failure of this hook will fail the uninstallation process, but the package is not uninstalled|
+
 ### Whalebrew images
 
 We maintain a set of packages which are known to follow these requirements under the `whalebrew` organization on [GitHub](https://github.com/whalebrew) and [Docker Hub](https://hub.docker.com/u/whalebrew/). If you want to add a package to this, open a pull request against [whalebrew-packages](https://github.com/whalebrew/whalebrew-packages).

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -8,11 +8,12 @@ import (
 	"path"
 
 	"github.com/Songmu/prompter"
-	"github.com/whalebrew/whalebrew/client"
-	"github.com/whalebrew/whalebrew/packages"
 	dockerClient "github.com/docker/docker/client"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/whalebrew/whalebrew/client"
+	"github.com/whalebrew/whalebrew/hooks"
+	"github.com/whalebrew/whalebrew/packages"
 )
 
 var customPackageName string
@@ -83,6 +84,11 @@ var installCommand = &cobra.Command{
 		}
 
 		pm := packages.NewPackageManager(viper.GetString("install_path"))
+
+		if err := hooks.Run("pre-install", imageName, pkg.Name); err != nil {
+			return fmt.Errorf("pre install script failed: %s", err.Error())
+		}
+
 		if forceInstall {
 			err = pm.ForceInstall(pkg)
 		} else {
@@ -91,6 +97,11 @@ var installCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		if err := hooks.Run("post-install", pkg.Name); err != nil {
+			return fmt.Errorf("post install script failed: %s", err.Error())
+		}
+
 		fmt.Printf("🐳  Installed %s to %s\n", imageName, path.Join(pm.InstallPath, pkg.Name))
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,14 +1,26 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
+func home() string {
+	if h := os.Getenv("HOME"); h != "" {
+		return h
+	}
+	return os.Getenv("USERPROFILE") // windows
+}
+
 func init() {
 	viper.SetEnvPrefix("whalebrew")
 	viper.SetDefault("install_path", "/usr/local/bin")
+	viper.SetDefault("config_dir", filepath.Join(home(), ".whalebrew"))
 	viper.BindEnv("install_path")
+	viper.BindEnv("config_dir")
 }
 
 // RootCmd is the root CLI command

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -5,9 +5,10 @@ import (
 	"path"
 
 	"github.com/Songmu/prompter"
-	"github.com/whalebrew/whalebrew/packages"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/whalebrew/whalebrew/hooks"
+	"github.com/whalebrew/whalebrew/packages"
 )
 
 func init() {
@@ -30,6 +31,10 @@ var uninstallCommand = &cobra.Command{
 
 		path := path.Join(pm.InstallPath, packageName)
 
+		if err := hooks.Run("pre-uninstall", packageName); err != nil {
+			return fmt.Errorf("pre-uninstall install script failed: %s", err.Error())
+		}
+
 		if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
 			return nil
 		}
@@ -39,7 +44,11 @@ var uninstallCommand = &cobra.Command{
 			return err
 		}
 
+		if err := hooks.Run("post-uninstall", packageName); err != nil {
+			return fmt.Errorf("post-uninstall install script failed: %s", err.Error())
+		}
 		fmt.Printf("🚽  Uninstalled %s\n", path)
+
 		return nil
 	},
 }

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -1,0 +1,76 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+type stater interface {
+	Stat(string) (os.FileInfo, error)
+}
+
+type runner interface {
+	Run(string, ...string) error
+}
+
+type dirGetChanger interface {
+	Chdir(string) error
+	Getwd() (string, error)
+}
+
+type osStater struct{}
+
+func (osStater) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+type execRunner struct{}
+
+func (execRunner) Run(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	return cmd.Run()
+}
+
+type osDirGetChanger struct{}
+
+func (osDirGetChanger) Getwd() (string, error) {
+	return os.Getwd()
+}
+func (osDirGetChanger) Chdir(path string) error {
+	return os.Chdir(path)
+}
+
+func run(s stater, r runner, wdChanger dirGetChanger, installPath string, hook string, args ...string) error {
+	hookPath := filepath.Join(installPath, ".whalebrew/hooks", hook)
+	wd, err := wdChanger.Getwd()
+	if err != nil {
+		return fmt.Errorf("unable to get current directory: %s", err.Error())
+	}
+	err = wdChanger.Chdir(installPath)
+	if err != nil {
+		return fmt.Errorf("unable to change directory to %s: %s", installPath, err.Error())
+	}
+	defer func() {
+		wdChanger.Chdir(wd)
+	}()
+	if stat, err := s.Stat(hookPath); err == nil {
+		if stat.IsDir() || stat.Mode().Perm()&0100 != 0100 {
+			return fmt.Errorf("%s: file is not executable", hookPath)
+		}
+		if err := r.Run(hookPath, args...); err != nil {
+			return fmt.Errorf("%s: %s", hookPath, err.Error())
+		}
+	}
+	return nil
+}
+
+func Run(hook string, args ...string) error {
+	return run(osStater{}, execRunner{}, osDirGetChanger{}, viper.GetString("install_path"), hook, args...)
+}

--- a/hooks/hooks.go
+++ b/hooks/hooks.go
@@ -47,8 +47,8 @@ func (osDirGetChanger) Chdir(path string) error {
 	return os.Chdir(path)
 }
 
-func run(s stater, r runner, wdChanger dirGetChanger, installPath string, hook string, args ...string) error {
-	hookPath := filepath.Join(installPath, ".whalebrew/hooks", hook)
+func run(s stater, r runner, wdChanger dirGetChanger, configDir, installPath string, hook string, args ...string) error {
+	hookPath := filepath.Join(configDir, "hooks", hook)
 	wd, err := wdChanger.Getwd()
 	if err != nil {
 		return fmt.Errorf("unable to get current directory: %s", err.Error())
@@ -72,5 +72,5 @@ func run(s stater, r runner, wdChanger dirGetChanger, installPath string, hook s
 }
 
 func Run(hook string, args ...string) error {
-	return run(osStater{}, execRunner{}, osDirGetChanger{}, viper.GetString("install_path"), hook, args...)
+	return run(osStater{}, execRunner{}, osDirGetChanger{}, viper.GetString("config_dir"), viper.GetString("install_path"), hook, args...)
 }

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -1,0 +1,186 @@
+package hooks
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+)
+
+type testRunner struct {
+	t    *testing.T
+	err  error
+	name string
+	args []string
+}
+
+func (tr testRunner) Run(name string, args ...string) error {
+	assert.Equal(tr.t, tr.name, name)
+	assert.EqualValues(tr.t, tr.args, args)
+	return tr.err
+}
+
+type testStater struct {
+	t        *testing.T
+	fileInfo os.FileInfo
+	err      error
+	name     string
+}
+
+func (ts testStater) Stat(name string) (os.FileInfo, error) {
+	assert.Equal(ts.t, ts.name, name)
+	return ts.fileInfo, ts.err
+}
+
+type testFileInfo struct {
+	mode  os.FileMode
+	isDir bool
+}
+
+func (testFileInfo) Name() string {
+	return ""
+}
+
+func (testFileInfo) Size() int64 {
+	return 0
+}
+
+func (tfi testFileInfo) Mode() os.FileMode {
+	return tfi.mode
+}
+
+func (testFileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (tfi testFileInfo) IsDir() bool {
+	return tfi.isDir
+}
+
+func (testFileInfo) Sys() interface{} {
+	return nil
+}
+
+type testDirChanger struct {
+	t         *testing.T
+	cwd       string
+	dirs      []string
+	getcwdErr error
+	chdirErr  error
+}
+
+func (tdc *testDirChanger) Getwd() (string, error) {
+	return tdc.cwd, tdc.getcwdErr
+}
+
+func (tdc *testDirChanger) Chdir(path string) error {
+	d := tdc.dirs[0]
+	tdc.dirs = tdc.dirs[1:]
+	assert.Equal(tdc.t, d, path)
+	return tdc.chdirErr
+}
+
+func TestRun(t *testing.T) {
+	t.Run("When the hook exists", func(t *testing.T) {
+		assert.NoError(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				osDirGetChanger{},
+				"/tmp",
+				"post-install"),
+		)
+		assert.NoError(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", []string{"an-argument"}},
+				&testDirChanger{t, "some/path", []string{"/tmp", "some/path"}, nil, nil},
+				"/tmp",
+				"post-install",
+				"an-argument"),
+		)
+	})
+	t.Run("When failing to get current directory", func(t *testing.T) {
+		assert.Error(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				&testDirChanger{t, "", nil, fmt.Errorf("testError"), nil},
+				"/tmp",
+				"post-install",
+				"an-argument"),
+		)
+	})
+	t.Run("When failing to change directory", func(t *testing.T) {
+		assert.Error(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				&testDirChanger{t, "some/path", []string{"/tmp/whalebrew"}, nil, fmt.Errorf("testError")},
+				"/tmp/whalebrew",
+				"post-install",
+				"an-argument"),
+		)
+	})
+	t.Run("When webhook is not executable", func(t *testing.T) {
+		assert.Error(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				osDirGetChanger{},
+				"/tmp",
+				"post-install",
+				"an-argument"),
+		)
+	})
+	t.Run("When webhook is a directory", func(t *testing.T) {
+		assert.Error(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0700), true}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				osDirGetChanger{},
+				"/tmp",
+				"post-install",
+				"an-argument"),
+		)
+	})
+
+	t.Run("When command fails exists", func(t *testing.T) {
+		assert.Error(
+			t,
+			run(
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testRunner{t, fmt.Errorf("test-error"), "/tmp/.whalebrew/hooks/post-install", []string{"an-argument"}},
+				osDirGetChanger{},
+				"/tmp",
+				"post-install",
+				"an-argument"),
+		)
+	})
+	t.Run("When the webhook does not exist", func(t *testing.T) {
+		viper.Set("install_path", ".")
+		fmt.Println(Run(
+			"post-install",
+			"an-argument"))
+		assert.NoError(
+			t,
+			Run(
+				"post-install",
+				"an-argument"),
+		)
+	})
+}
+
+func TestExecRunner(t *testing.T) {
+	assert.NoError(t, execRunner{}.Run("ls", "-al"))
+	assert.Error(t, execRunner{}.Run("false"))
+}

--- a/hooks/hooks_test.go
+++ b/hooks/hooks_test.go
@@ -88,18 +88,20 @@ func TestRun(t *testing.T) {
 		assert.NoError(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/home/user/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/home/user/.whalebrew/hooks/post-install", nil},
 				osDirGetChanger{},
+				"/home/user/.whalebrew",
 				"/tmp",
 				"post-install"),
 		)
 		assert.NoError(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", []string{"an-argument"}},
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/home/other/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "/home/other/.whalebrew/hooks/post-install", []string{"an-argument"}},
 				&testDirChanger{t, "some/path", []string{"/tmp", "some/path"}, nil, nil},
+				"/home/other/.whalebrew",
 				"/tmp",
 				"post-install",
 				"an-argument"),
@@ -109,9 +111,10 @@ func TestRun(t *testing.T) {
 		assert.Error(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/home/other/.whalebrew/hooks/post-install"},
 				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
-				&testDirChanger{t, "", nil, fmt.Errorf("testError"), nil},
+				&testDirChanger{t, "should-be-ignored", nil, fmt.Errorf("testError"), nil},
+				"/home/other/.whalebrew",
 				"/tmp",
 				"post-install",
 				"an-argument"),
@@ -121,9 +124,10 @@ func TestRun(t *testing.T) {
 		assert.Error(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
-				&testDirChanger{t, "some/path", []string{"/tmp/whalebrew"}, nil, fmt.Errorf("testError")},
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/home/other/.whalebrew/hooks/post-install"},
+				testRunner{t, nil, "should-be-ignored", nil},
+				&testDirChanger{t, "should-be-ignored", []string{"/tmp/whalebrew"}, nil, fmt.Errorf("testError")},
+				"/home/other/.whalebrew",
 				"/tmp/whalebrew",
 				"post-install",
 				"an-argument"),
@@ -133,9 +137,10 @@ func TestRun(t *testing.T) {
 		assert.Error(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				testStater{t, testFileInfo{os.FileMode(0600), false}, nil, "/tmp/whalebrew/hooks/post-install"},
+				testRunner{t, nil, "should-be-ignored", nil},
 				osDirGetChanger{},
+				"/tmp/whalebrew",
 				"/tmp",
 				"post-install",
 				"an-argument"),
@@ -145,22 +150,24 @@ func TestRun(t *testing.T) {
 		assert.Error(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0700), true}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, nil, "/tmp/.whalebrew/hooks/post-install", nil},
+				testStater{t, testFileInfo{os.FileMode(0700), true}, nil, "/tmp/whalebrew/hooks/post-install"},
+				testRunner{t, nil, "should-be-ignored", nil},
 				osDirGetChanger{},
+				"/tmp/whalebrew",
 				"/tmp",
 				"post-install",
 				"an-argument"),
 		)
 	})
 
-	t.Run("When command fails exists", func(t *testing.T) {
+	t.Run("When command fails", func(t *testing.T) {
 		assert.Error(
 			t,
 			run(
-				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/.whalebrew/hooks/post-install"},
-				testRunner{t, fmt.Errorf("test-error"), "/tmp/.whalebrew/hooks/post-install", []string{"an-argument"}},
+				testStater{t, testFileInfo{os.FileMode(0700), false}, nil, "/tmp/whalebrew/hooks/post-install"},
+				testRunner{t, fmt.Errorf("test-error"), "/tmp/whalebrew/hooks/post-install", []string{"an-argument"}},
 				osDirGetChanger{},
+				"/tmp/whalebrew",
 				"/tmp",
 				"post-install",
 				"an-argument"),
@@ -168,6 +175,7 @@ func TestRun(t *testing.T) {
 	})
 	t.Run("When the webhook does not exist", func(t *testing.T) {
 		viper.Set("install_path", ".")
+		viper.Set("config_dir", ".")
 		fmt.Println(Run(
 			"post-install",
 			"an-argument"))


### PR DESCRIPTION
As discussed in #59, users may need to add custom behaviours on specific actions (commit the yaml file, validate the image, ...)
This PR adds support for such feature, allowing users to hook into the installation and removal process to provide value they need
