### PR TITLE
Remove the run subcommand

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,85 +9,88 @@ import (
 	"syscall"
 
 	"github.com/whalebrew/whalebrew/packages"
-	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
-func init() {
-	RootCmd.AddCommand(runCommand)
-}
+// Run runs a package after extracting arguments
+func Run(args []string) error {
+	pkg, err := packages.LoadPackageFromPath(args[0])
+	if err != nil {
+		return err
+	}
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		return err
+	}
 
-var runCommand = &cobra.Command{
-	Use:                "run PACKAGEPATH [ARGS ...]",
-	Short:              "Run a package",
-	DisableFlagParsing: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if len(args) < 1 {
-			return cmd.Help()
-		}
-
-		pkg, err := packages.LoadPackageFromPath(args[0])
-		if err != nil {
-			return err
-		}
-		dockerPath, err := exec.LookPath("docker")
-		if err != nil {
-			return err
-		}
-
-		cwd, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-		dockerArgs := []string{
-			dockerPath,
-			"run",
-			"--interactive",
-			"--rm",
-			"--workdir", os.ExpandEnv(pkg.WorkingDir),
-			"-v", fmt.Sprintf("%s:%s", cwd, os.ExpandEnv(pkg.WorkingDir)),
-			"--init",
-		}
-		if terminal.IsTerminal(int(os.Stdin.Fd())) {
-			dockerArgs = append(dockerArgs, "--tty")
-		}
-		for _, volume := range pkg.Volumes {
-			// special case expanding home directory
-			if strings.HasPrefix(volume, "~/") {
-				user, err := user.Current()
-				if err != nil {
-					return err
-				}
-				volume = user.HomeDir + volume[1:]
-			}
-			dockerArgs = append(dockerArgs, "-v")
-			dockerArgs = append(dockerArgs, os.ExpandEnv(volume))
-		}
-		for _, envvar := range pkg.Environment {
-			dockerArgs = append(dockerArgs, "-e")
-			dockerArgs = append(dockerArgs, os.ExpandEnv(envvar))
-		}
-		for _, portmap := range pkg.Ports {
-			dockerArgs = append(dockerArgs, "-p")
-			dockerArgs = append(dockerArgs, portmap)
-		}
-		for _, network := range pkg.Networks {
-			dockerArgs = append(dockerArgs, "--net")
-			dockerArgs = append(dockerArgs, network)
-		}
-
-		if !pkg.KeepContainerUser {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	dockerArgs := []string{
+		dockerPath,
+		"run",
+		"--interactive",
+		"--rm",
+		"--workdir", os.ExpandEnv(pkg.WorkingDir),
+		"-v", fmt.Sprintf("%s:%s", cwd, os.ExpandEnv(pkg.WorkingDir)),
+		"--init",
+	}
+	if terminal.IsTerminal(int(os.Stdin.Fd())) {
+		dockerArgs = append(dockerArgs, "--tty")
+	}
+	for _, volume := range pkg.Volumes {
+		// special case expanding home directory
+		if strings.HasPrefix(volume, "~/") {
 			user, err := user.Current()
 			if err != nil {
 				return err
 			}
-			dockerArgs = append(dockerArgs, "-u")
-			dockerArgs = append(dockerArgs, user.Uid+":"+user.Gid)
+			volume = user.HomeDir + volume[1:]
 		}
+		dockerArgs = append(dockerArgs, "-v")
+		dockerArgs = append(dockerArgs, os.ExpandEnv(volume))
+	}
+	for _, envvar := range pkg.Environment {
+		dockerArgs = append(dockerArgs, "-e")
+		dockerArgs = append(dockerArgs, os.ExpandEnv(envvar))
+	}
+	for _, portmap := range pkg.Ports {
+		dockerArgs = append(dockerArgs, "-p")
+		dockerArgs = append(dockerArgs, portmap)
+	}
+	for _, network := range pkg.Networks {
+		dockerArgs = append(dockerArgs, "--net")
+		dockerArgs = append(dockerArgs, network)
+	}
 
-		dockerArgs = append(dockerArgs, pkg.Image)
-		dockerArgs = append(dockerArgs, args[1:]...)
+	if !pkg.KeepContainerUser {
+		user, err := user.Current()
+		if err != nil {
+			return err
+		}
+		dockerArgs = append(dockerArgs, "-u")
+		dockerArgs = append(dockerArgs, user.Uid+":"+user.Gid)
+	}
 
-		return syscall.Exec(dockerPath, dockerArgs, os.Environ())
-	},
+	dockerArgs = append(dockerArgs, pkg.Image)
+	dockerArgs = append(dockerArgs, args[1:]...)
+
+	return syscall.Exec(dockerPath, dockerArgs, os.Environ())
+}
+
+// IsShellbang returns whether the arguments should be interpreted as a shellbang run
+func IsShellbang(args []string) bool {
+	if len(args) < 2 {
+		// a shellbang #!/usr/bin/env whalebrew
+		// will always have at least <pathTo>/whalebrew <file>
+		return false
+	}
+	// args are like <pathTo>/whalebrew <file>
+	// When used as shellbang, the user ran <file> which leaded
+	// to open it, read the shellbang line and run prefxing the
+	// extended absolute <file> path with the shellbang command.
+	// We are also sure that it cannot be a sub command as no sub-command starts with /
+	// This disables the option to `whalebrew ./package.yaml`
+	return strings.HasPrefix(args[1], "/")
 }

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,22 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/whalebrew/whalebrew/cmd"
+)
+
+func TestIsShellbang(t *testing.T) {
+	t.Run("when called without enough arguments, command is not detected as shellbang", func(t *testing.T) {
+		assert.False(t, cmd.IsShellbang([]string{}))
+	})
+
+	t.Run("when called with a subcommand, command is not detected as shellbang", func(t *testing.T) {
+		assert.False(t, cmd.IsShellbang([]string{"whalebrew", "list"}))
+	})
+
+	t.Run("when called with an absolute path, command is detected as shellbang", func(t *testing.T) {
+		assert.True(t, cmd.IsShellbang([]string{"whalebrew", "/usr/local/bin/curl"}))
+	})
+}

--- a/main.go
+++ b/main.go
@@ -3,20 +3,19 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/whalebrew/whalebrew/cmd"
 )
 
 func main() {
-	// HACK: if first argument starts with "/", prefix the subcommand run.
-	// This allows us to use this command as a shebang, because we can't pass
-	// the argument "run" in the shebang on Linux.
-	if len(os.Args) > 1 && strings.HasPrefix(os.Args[1], "/") {
-		cmd.RootCmd.SetArgs(append([]string{"run"}, os.Args[1:]...))
+	var err error
+	if cmd.IsShellbang(os.Args){
+		err = cmd.Run(os.Args)
+	} else {
+		err = cmd.RootCmd.Execute()
 	}
 
-	if err := cmd.RootCmd.Execute(); err != nil {
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}


### PR DESCRIPTION
As detailed in #66, run subcommand is an internal command that is
"not designed to be used by a user"

Remove the run command hack to inject an sub command and stop exposing
the internal sub command to the user

fixes: #63