### PR TITLE
Improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,28 @@
-FROM golang:1.12
+ARG GO_VERSION=1.12
+ARG DOCKER_VERSION=18.06
+
+FROM docker:${DOCKER_VERSION} as docker-cli
+FROM golang:${GO_VERSION}-alpine as go
+FROM go as build
 
 WORKDIR /src
+
+# build-base is required for tests
+RUN apk add --no-cache \
+    build-base \
+    git
 
 COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN GO111MODULE=on go install .
-CMD ["whalebrew"]
+RUN go test -v ./...
+RUN go install .
+
+FROM alpine
+ENTRYPOINT ["whalebrew"]
+LABEL io.whalebrew.config.volumes '["/var/run/docker.sock:/var/run/docker.sock", "${WHALEBREW_INSTALL_PATH}:/usr/local/bin"]'
+LABEL io.whalebrew.config.keep_container_user 'true'
+
+COPY --from=docker-cli /usr/local/bin/docker /bin/docker
+COPY --from=build /go/bin/whalebrew /bin/whalebrew

--- a/script/run
+++ b/script/run
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-docker build -t whalebrew .
+docker build --target build -t whalebrew .
 exec docker run -it --rm whalebrew "$@"

--- a/script/test
+++ b/script/test
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-docker build -t whalebrew .
+docker build  --target build -t whalebrew .
 exec docker run --rm whalebrew go test ./...


### PR DESCRIPTION
Rework Dockerfile to provide a minimal image.
This image can then easily be ran through
`docker run --rm -v<PathToExecutable>:/executable -v /var/run/docker.sock:/var/run/docker.sock whalebrew/whalebrew /executable <args>`

fixes #32

A step forward for #36