### PR TITLE
Add support to handle missing volumes in custom ways

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,14 @@ There are some labels you can use to configure how Whalebrew installs your image
 
         LABEL io.whalebrew.config.keep_container_user 'true'
 
+* `io.whalebrew.config.missing_volumes`: The behaviour to handle missing files or volumes into the container.
+
+        LABEL io.whalebrew.config.skip_missing_volumes 'skip'
+
+        Possible values are
+        - 'error' to raise an error when trying to mount a non existing volume *this is the default behaviour*
+        - 'skip' to prevent binding the volume
+        - 'mount' to mount the volume anyway. This will result in docker [creating a host directory](https://docs.docker.com/engine/reference/commandline/run/#mount-volume--v---read-only)
 
 #### Using user environment variables
 

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/whalebrew/whalebrew/packages"
+)
+
+func TestShouldBind(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	t.Run("with a file that exists", func(t *testing.T) {
+		t.Run("when not skipping missing volumes", func(t *testing.T) {
+			bind, err := shouldBind(filepath.Join(wd, "run.go"), &packages.Package{SkipMissingVolumes: false})
+			assert.NoError(t, err)
+			assert.True(t, bind)
+		})
+		t.Run("when skipping missing volumes", func(t *testing.T) {
+			bind, err := shouldBind(filepath.Join(wd, "run.go"), &packages.Package{SkipMissingVolumes: true})
+			assert.NoError(t, err)
+			assert.True(t, bind)
+		})
+	})
+	t.Run("with a file that does not exists", func(t *testing.T) {
+		t.Run("when not skipping missing volumes", func(t *testing.T) {
+			bind, err := shouldBind(filepath.Join(wd, "thisFileShouldNotExist.go"), &packages.Package{SkipMissingVolumes: false})
+			assert.Error(t, err)
+			assert.False(t, bind)
+		})
+		t.Run("when skipping missing volumes", func(t *testing.T) {
+			bind, err := shouldBind(filepath.Join(wd, "thisFileShouldNotExist.go"), &packages.Package{SkipMissingVolumes: true})
+			assert.NoError(t, err)
+			assert.False(t, bind)
+		})
+		t.Run("when mounting missing volumes", func(t *testing.T) {
+			bind, err := shouldBind(filepath.Join(wd, "thisFileShouldNotExist.go"), &packages.Package{MountMissingVolumes: true})
+			assert.NoError(t, err)
+			assert.True(t, bind)
+		})
+	})
+}
+
+func TestAppendVolumes(t *testing.T) {
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	volumes := []string{
+		filepath.Join(wd, "thisFileShouldNotExist.go:/notExists"),
+		filepath.Join(wd, "run.go:/exists"),
+		"~/:/home/user",
+	}
+	t.Run("when non existing volumes should be skept", func(t *testing.T) {
+		args, err := appendVolumes(nil, &packages.Package{SkipMissingVolumes: true, Volumes: volumes})
+		assert.NoError(t, err)
+		assert.NotNil(t, args)
+		assert.Len(t, args, 4)
+		t.Run("all existing volumes instructed to mount on command line", func(t *testing.T) {
+			assert.Equal(t, []string{"-v", fmt.Sprintf("%s/run.go:/exists", wd), "-v"}, args[:3])
+			if !strings.HasSuffix(args[3], "/:/home/user") {
+				t.Errorf("home volume should be mounted")
+			}
+			if strings.HasPrefix(args[3], "~") {
+				t.Errorf("~/ prefix should be replaced by current user home directory")
+			}
+		})
+	})
+	t.Run("when non existing volumes should be mounted", func(t *testing.T) {
+		args, err := appendVolumes(nil, &packages.Package{MountMissingVolumes: true, Volumes: volumes})
+		assert.NoError(t, err)
+		assert.NotNil(t, args)
+		assert.Len(t, args, 6)
+		t.Run("all existing volumes instructed to mount on command line", func(t *testing.T) {
+			assert.Equal(t, []string{"-v", fmt.Sprintf("%s/thisFileShouldNotExist.go:/notExists", wd), "-v", fmt.Sprintf("%s/run.go:/exists", wd), "-v"}, args[:5])
+			if !strings.HasSuffix(args[5], "/:/home/user") {
+				t.Errorf("home volume should be mounted")
+			}
+			if strings.HasPrefix(args[5], "~") {
+				t.Errorf("~/ prefix should be replaced by current user home directory")
+			}
+		})
+	})
+	t.Run("when non existing volumes should not be skept", func(t *testing.T) {
+		args, err := appendVolumes(nil, &packages.Package{SkipMissingVolumes: false, Volumes: volumes})
+		assert.Error(t, err)
+		assert.Nil(t, args)
+	})
+}


### PR DESCRIPTION
Change the default behaviour to raise an error when a volume to bind is
missing.
fixes: #38

Other supported behaviours:
- skip (the container will not have the given path mounted)
- mount (the volume will be created by docker as a directory, owned by
  root)