### PR TITLE
Add support for custom entrypoint

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -17,11 +17,13 @@ import (
 )
 
 var customPackageName string
+var customEntrypoint string
 var forceInstall bool
 var assumeYes bool
 
 func init() {
 	installCommand.Flags().StringVarP(&customPackageName, "name", "n", "", "Name to give installed package. Defaults to image name.")
+	installCommand.Flags().StringVarP(&customEntrypoint, "entrypoint", "e", "", "Alternate entrypoint to run the image with. Defaults to image entrypoint.")
 	installCommand.Flags().BoolVarP(&forceInstall, "force", "f", false, "Replace existing package if already exists. Defaults to false.")
 	installCommand.Flags().BoolVarP(&assumeYes, "assume-yes", "y", false, "Assume 'yes' as answer to all prompts and run non-interactively. Defaults to false.")
 
@@ -71,6 +73,10 @@ var installCommand = &cobra.Command{
 		}
 		if customPackageName != "" {
 			pkg.Name = customPackageName
+		}
+
+		if customEntrypoint != "" {
+			pkg.Entrypoint = []string{customEntrypoint}
 		}
 
 		preinstallMessage := pkg.PreinstallMessage()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -61,6 +61,7 @@ func Run(args []string) error {
 	if err != nil {
 		return err
 	}
+	args = args[2:]
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
 		return err
@@ -78,6 +79,14 @@ func Run(args []string) error {
 		"--workdir", os.ExpandEnv(pkg.WorkingDir),
 		"-v", fmt.Sprintf("%s:%s", cwd, os.ExpandEnv(pkg.WorkingDir)),
 		"--init",
+	}
+	if pkg.Entrypoint != nil {
+		if len(pkg.Entrypoint) > 0 {
+			dockerArgs = append(dockerArgs, "--entrypoint", pkg.Entrypoint[0])
+			if len(pkg.Entrypoint) > 1 {
+				args = append(pkg.Entrypoint[1:], args...)
+			}
+		}
 	}
 	if terminal.IsTerminal(int(os.Stdin.Fd())) {
 		dockerArgs = append(dockerArgs, "--tty")
@@ -109,7 +118,7 @@ func Run(args []string) error {
 	}
 
 	dockerArgs = append(dockerArgs, pkg.Image)
-	dockerArgs = append(dockerArgs, args[2:]...)
+	dockerArgs = append(dockerArgs, args...)
 
 	return syscall.Exec(dockerPath, dockerArgs, os.Environ())
 }

--- a/packages/package.go
+++ b/packages/package.go
@@ -16,6 +16,7 @@ import (
 // Package represents a Whalebrew package
 type Package struct {
 	Name                string   `yaml:"-"`
+	Entrypoint          []string `yaml:"entrypoint,omitempty"`
 	Environment         []string `yaml:"environment,omitempty"`
 	Image               string   `yaml:"image"`
 	Volumes             []string `yaml:"volumes,omitempty"`


### PR DESCRIPTION
This PR implements the same as #66 with the difference that the entry point is only stored in the package file and can be defined at install time.

Unlike #66 this PR does not allow customisation at the run time, being an internal and undocumented feature

Eventually, this could open the opportunity to add "additional commands" in a given package like `io.whalebrew.additional_packages: {"other-command": ["ls", "-al"]}`