### PR TITLE
Fix invalid name when using a custom registry

### DIFF
--- a/packages/package.go
+++ b/packages/package.go
@@ -33,9 +33,8 @@ type Package struct {
 // inspecting the image to fetch the package configuration
 func NewPackageFromImage(image string, imageInspect types.ImageInspect) (*Package, error) {
 	name := image
-	if strings.Contains(name, "/") {
-		name = strings.SplitN(name, "/", 2)[1]
-	}
+	splittedName := strings.Split(name, "/")
+	name = splittedName[len(splittedName)-1]
 	if strings.Contains(name, ":") {
 		name = strings.SplitN(name, ":", 2)[0]
 	}

--- a/packages/package_test.go
+++ b/packages/package_test.go
@@ -22,6 +22,15 @@ func mustNewTestPkg(t *testing.T, label, value string) *Package {
 	return pkg
 }
 
+func mustNewTestPackageFromImage(t *testing.T, imageName string) *Package {
+	pkg, err := NewPackageFromImage(imageName, types.ImageInspect{
+		ContainerConfig: &container.Config{
+		},
+	})
+	assert.NoErrorf(t, err, "creating a package for image '%s' should not raise an error", imageName)
+	return pkg
+}
+
 func TestNewPackageFromImage(t *testing.T) {
 	// with tag
 	pkg, err := NewPackageFromImage("whalebrew/foo:bar", types.ImageInspect{})
@@ -47,6 +56,9 @@ func TestNewPackageFromImage(t *testing.T) {
 
 	assert.False(t, mustNewTestPkg(t, "any", "ws").MountMissingVolumes)
 	assert.False(t, mustNewTestPkg(t, "any", "other").SkipMissingVolumes)
+
+	assert.Equal(t, "example", mustNewTestPackageFromImage(t, "quay.io/some/registry/example").Name)
+	assert.Equal(t, "quay.io/some/registry/example", mustNewTestPackageFromImage(t, "quay.io/some/registry/example").Image)
 
 	_, err = newTestPkg("io.whalebrew.config.missing_volumes", "some-other")
 	assert.Error(t, err)


### PR DESCRIPTION
When using a custom registry, the image name is often of "registry.io/org/image"

The previous implementation was splitting on / to compute the path of
the executable to dump and hence was trying to create ${WHALEBREW_INSTALL_PATH}/org/image
the org directory being more likely to not exist, and be outside of
$PATH

This implementation considers the image name as a full path and gets
"image" as executable name, installing it to ${WHALEBREW_INSTALL_PATH}/image