### PR TITLE
Add an option to mount paths provided in flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ There are some labels you can use to configure how Whalebrew installs your image
 
 * `io.whalebrew.required_version`: Specifies the minimum whalebrew version to required to run the package. Examples: `<1.0.0`, `>0.1.0`, `>0.1.0 <1.0.0`
 
+* `io.whalebrew.config.volumes_from_args`: A list of command line arguments of the program passed at runtime that must be consideredand mounted as volumes:
+
+        LABEL io.whalebrew.config.volumes_from_args '["-C", "--exec-path"]'
+
 #### Using user environment variables
 
 The labels `io.whalebrew.config.working_dir`, `io.whalebrew.config.volumes` and `io.whalebrew.config.environment` are expanded with user environment variables when the container is launched.

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -89,3 +89,17 @@ func TestAppendVolumes(t *testing.T) {
 		assert.Nil(t, args)
 	})
 }
+
+func TestParseRuntimeVolumes(t *testing.T) {
+	pkg := &packages.Package{
+		PathArguments: []string{"C", "exec-path", "X", "stream"},
+	}
+
+	wd, err := os.Getwd()
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		[]string{"/tmp:/tmp", "/other/path:/other/path", "/some/path:/some/path", fmt.Sprintf("%s/local:%s/local", wd, wd), "/something:/something"},
+		parseRuntimeVolumes([]string{"-C/tmp", "--other", "arg", "--exec-path", "/some/path", "-C", "/other/path", "--exec-path=local", "--stream", "-", "-X", "/dev/stdin", "-X/something"}, pkg),
+	)
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/sirupsen/logrus v1.4.1 // indirect
 	github.com/spf13/cobra v0.0.4-0.20190321000552-67fc4837d267
+	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.2.2
 	golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5

--- a/packages/package.go
+++ b/packages/package.go
@@ -31,6 +31,7 @@ type Package struct {
 	SkipMissingVolumes  bool     `yaml:"skip_missing_volumes,omitempty"`
 	MountMissingVolumes bool     `yaml:"mount_missing_volumes,omitempty"`
 	RequiredVersion     string   `yaml:"required_version,omitempty"`
+	PathArguments       []string `yaml:"path_arguments,omitempty"`
 }
 
 // NewPackageFromImage creates a package from a given image name,
@@ -80,6 +81,16 @@ func NewPackageFromImage(image string, imageInspect types.ImageInspect) (*Packag
 			if volumesStr, ok := labels["io.whalebrew.config.volumes"]; ok {
 				if err := yaml.Unmarshal([]byte(volumesStr), &pkg.Volumes); err != nil {
 					return pkg, err
+				}
+			}
+
+			if pathArgs, ok := labels["io.whalebrew.config.volumes_from_args"]; ok {
+				args := []string{}
+				if err := yaml.Unmarshal([]byte(pathArgs), &args); err != nil {
+					return pkg, err
+				}
+				for _, arg := range args {
+					pkg.PathArguments = append(pkg.PathArguments, strings.TrimLeft(arg, "-"))
 				}
 			}
 

--- a/packages/package_test.go
+++ b/packages/package_test.go
@@ -24,8 +24,7 @@ func mustNewTestPkg(t *testing.T, label, value string) *Package {
 
 func mustNewTestPackageFromImage(t *testing.T, imageName string) *Package {
 	pkg, err := NewPackageFromImage(imageName, types.ImageInspect{
-		ContainerConfig: &container.Config{
-		},
+		ContainerConfig: &container.Config{},
 	})
 	assert.NoErrorf(t, err, "creating a package for image '%s' should not raise an error", imageName)
 	return pkg
@@ -44,6 +43,7 @@ func TestNewPackageFromImage(t *testing.T) {
 	assert.Equal(t, []string{"/somesource:/somedest"}, mustNewTestPkg(t, "io.whalebrew.config.volumes", `["/somesource:/somedest"]`).Volumes)
 	assert.Equal(t, []string{"8100:8100"}, mustNewTestPkg(t, "io.whalebrew.config.ports", `["8100:8100"]`).Ports)
 	assert.Equal(t, []string{"host"}, mustNewTestPkg(t, "io.whalebrew.config.networks", `["host"]`).Networks)
+	assert.Equal(t, []string{"C", "exec-path"}, mustNewTestPkg(t, "io.whalebrew.config.volumes_from_args", `["-C", "--exec-path"]`).PathArguments)
 
 	assert.True(t, mustNewTestPkg(t, "io.whalebrew.config.missing_volumes", "mount").MountMissingVolumes)
 	assert.False(t, mustNewTestPkg(t, "io.whalebrew.config.missing_volumes", "mount").SkipMissingVolumes)


### PR DESCRIPTION
When providing filepath on the commandline like `$ wget -O
../google.html https://www.google.com` the destination path is not bound
in the current and hence the user does not see the output file.

With the proposed implementation, the package provider should provide
flags that should contain path to files. Then, whalebrew will parse
those flags and extract volume names from it, instructing to bind those
inside the container.

There is no message added at the install time. Rationale is that the
user provides the paths himself, and hence he expects the path to be
bound. Unlike volumes that are bundled inside the image package.

I am foreseeing few issues to be addressed:
- in case a path is a file it might happen that the output is actually
  not flushed inside the host. It has been tested on OSX and seems to
  work though
- in case the path is a file and does not exist, we would expect it to
  be replicated with same user and permissions as in the container.
  Instead, an error will be raised that the file does not exist
- in case the path is ~/<something> or $HOME/<something>, it would
  probably be expected to map it to HOME in the container. Though the
  detection is quite hard to do. The HOME in the container is unknown
  and there is no trivial decision wether the intent is to handle it as
  relative to the HOME directory or if it is important that the actual
  fully provided path is forwarded

This change actually updates the in-memory package update at runtime,
which might introduce the need to introduce a runtime object to run the
command

Fixes: #22