### PR TITLE
Update version number in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ First, [install Docker](https://docs.docker.com/engine/installation/). The easie
 
 Next, on macOS and Linux:
 
-    curl -L "https://github.com/whalebrew/whalebrew/releases/download/0.1.0/whalebrew-$(uname -s)-$(uname -m)" -o /usr/local/bin/whalebrew; chmod +x /usr/local/bin/whalebrew
+    curl -L "https://github.com/whalebrew/whalebrew/releases/download/0.2.3/whalebrew-$(uname -s)-$(uname -m)" -o /usr/local/bin/whalebrew; chmod +x /usr/local/bin/whalebrew
 
 Windows support is theoretically possible, but not implemented yet.
 


### PR DESCRIPTION
This PR updates version number in installation instructions in README.md. It should be updated automatically, but I update it with manual for now.

/ref #33 