### PR TITLE
Fix pkg not installable when entrypoint is not the last step

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -63,7 +63,7 @@ var installCommand = &cobra.Command{
 				return fmt.Errorf("failed to inspect docker image: %v", err)
 			}
 		}
-		if imageInspect.ContainerConfig.Entrypoint == nil {
+		if imageInspect.Config.Entrypoint == nil {
 			return fmt.Errorf("the image '%s' is not compatible with Whalebrew: it does not have an entrypoint", imageName)
 		}
 


### PR DESCRIPTION
From the docker inspect, ContainerConfig contains the configuration the the latest step of the docker build.
This means the entrypoint is only considered then it is the last step of the docker build.

However, the Config field contains the actual image configuration and the correct entrypoint regardless the position of the entrypoint

a Dockerfile of

```
FROM alpine
ENTRYPOINT ["sh"]
RUN echo hello world
```

gets a ContainerConfig of

```
"ContainerConfig": {
    "Hostname": "",
    "Domainname": "",
    "User": "",
    "AttachStdin": false,
    "AttachStdout": false,
    "AttachStderr": false,
    "Tty": false,
    "OpenStdin": false,
    "StdinOnce": false,
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Cmd": [
        "/bin/sh",
        "-c",
        "echo hello world"
    ],
    "ArgsEscaped": true,
    "Image": "sha256:a3c76edef3354652ffe1ce33205253dea58c6553d4c7bbb919bb3ff26bbb97d1",
    "Volumes": null,
    "WorkingDir": "",
    "Entrypoint": null,
    "OnBuild": null,
    "Labels": null
},
```

and a Config of

```
"Config": {
    "Hostname": "",
    "Domainname": "",
    "User": "",
    "AttachStdin": false,
    "AttachStdout": false,
    "AttachStderr": false,
    "Tty": false,
    "OpenStdin": false,
    "StdinOnce": false,
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
    ],
    "Cmd": null,
    "ArgsEscaped": true,
    "Image": "sha256:a3c76edef3354652ffe1ce33205253dea58c6553d4c7bbb919bb3ff26bbb97d1",
    "Volumes": null,
    "WorkingDir": "",
    "Entrypoint": [
        "sh"
    ],
    "OnBuild": null,
    "Labels": null
},
```