### PR TITLE
Extract run to a separate package

### DIFF
--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -54,37 +54,37 @@ func TestAppendVolumes(t *testing.T) {
 		"~/:/home/user",
 	}
 	t.Run("when non existing volumes should be skept", func(t *testing.T) {
-		args, err := appendVolumes(nil, &packages.Package{SkipMissingVolumes: true, Volumes: volumes})
+		volumes, err := getVolumes(&packages.Package{SkipMissingVolumes: true, Volumes: volumes})
 		assert.NoError(t, err)
-		assert.NotNil(t, args)
-		assert.Len(t, args, 4)
+		assert.NotNil(t, volumes)
+		assert.Len(t, volumes, 3)
 		t.Run("all existing volumes instructed to mount on command line", func(t *testing.T) {
-			assert.Equal(t, []string{"-v", fmt.Sprintf("%s/run.go:/exists", wd), "-v"}, args[:3])
-			if !strings.HasSuffix(args[3], "/:/home/user") {
+			assert.Equal(t, []string{fmt.Sprintf("%s/run.go:/exists", wd)}, volumes[:1])
+			if !strings.HasSuffix(volumes[1], "/:/home/user") {
 				t.Errorf("home volume should be mounted")
 			}
-			if strings.HasPrefix(args[3], "~") {
+			if strings.HasPrefix(volumes[1], "~") {
 				t.Errorf("~/ prefix should be replaced by current user home directory")
 			}
 		})
 	})
 	t.Run("when non existing volumes should be mounted", func(t *testing.T) {
-		args, err := appendVolumes(nil, &packages.Package{MountMissingVolumes: true, Volumes: volumes})
+		args, err := getVolumes(&packages.Package{MountMissingVolumes: true, Volumes: volumes})
 		assert.NoError(t, err)
 		assert.NotNil(t, args)
-		assert.Len(t, args, 6)
+		assert.Len(t, args, 4)
 		t.Run("all existing volumes instructed to mount on command line", func(t *testing.T) {
-			assert.Equal(t, []string{"-v", fmt.Sprintf("%s/thisFileShouldNotExist.go:/notExists", wd), "-v", fmt.Sprintf("%s/run.go:/exists", wd), "-v"}, args[:5])
-			if !strings.HasSuffix(args[5], "/:/home/user") {
+			assert.Equal(t, []string{fmt.Sprintf("%s/thisFileShouldNotExist.go:/notExists", wd), fmt.Sprintf("%s/run.go:/exists", wd)}, args[:2])
+			if !strings.HasSuffix(args[2], "/:/home/user") {
 				t.Errorf("home volume should be mounted")
 			}
-			if strings.HasPrefix(args[5], "~") {
+			if strings.HasPrefix(args[2], "~") {
 				t.Errorf("~/ prefix should be replaced by current user home directory")
 			}
 		})
 	})
 	t.Run("when non existing volumes should not be skept", func(t *testing.T) {
-		args, err := appendVolumes(nil, &packages.Package{SkipMissingVolumes: false, Volumes: volumes})
+		args, err := getVolumes(&packages.Package{SkipMissingVolumes: false, Volumes: volumes})
 		assert.Error(t, err)
 		assert.Nil(t, args)
 	})

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,11 +1,21 @@
 package cmd_test
 
 import (
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/whalebrew/whalebrew/cmd"
+	"github.com/whalebrew/whalebrew/packages"
+	"github.com/whalebrew/whalebrew/run"
 )
+
+type testRunner func(p *packages.Package, e *run.Execution) error
+
+func (tr testRunner) Run(p *packages.Package, e *run.Execution) error {
+	return tr(p, e)
+}
 
 func TestIsShellbang(t *testing.T) {
 	t.Run("when called without enough arguments, command is not detected as shellbang", func(t *testing.T) {
@@ -19,4 +29,22 @@ func TestIsShellbang(t *testing.T) {
 	t.Run("when called with an absolute path, command is detected as shellbang", func(t *testing.T) {
 		assert.True(t, cmd.IsShellbang([]string{"whalebrew", "/usr/local/bin/curl"}))
 	})
+}
+
+func TestRun(t *testing.T) {
+	f := func(p *packages.Package, e *run.Execution) error {
+		return errors.New("test error")
+	}
+	assert.Error(t, cmd.Run(testRunner(f), []string{"whalebrew", "../packages/resources/aws"}))
+	os.Setenv("TEST_ENVIRONMENT_VARIABLE", "SOME-VALUE")
+	f = func(p *packages.Package, e *run.Execution) error {
+		assert.Contains(t, e.Environment, "TEST_ENV=SOME-VALUE")
+		assert.Equal(t, 2, len(e.Volumes))
+		return nil
+	}
+	assert.NoError(t, cmd.Run(testRunner(f), []string{"whalebrew", "../packages/resources/aws"}))
+	f = func(p *packages.Package, e *run.Execution) error {
+		return nil
+	}
+	assert.Error(t, cmd.Run(testRunner(f), []string{"whalebrew", "./this-package-does-not-exist", "arg1"}))
 }

--- a/main.go
+++ b/main.go
@@ -9,8 +9,8 @@ import (
 
 func main() {
 	var err error
-	if cmd.IsShellbang(os.Args){
-		err = cmd.Run(os.Args)
+	if cmd.IsShellbang(os.Args) {
+		err = cmd.DockerCLIRun(os.Args)
 	} else {
 		err = cmd.RootCmd.Execute()
 	}

--- a/packages/resources/aws
+++ b/packages/resources/aws
@@ -6,7 +6,9 @@ environment:
 - AWS_DEFAULT_REGION
 - AWS_DEFAULT_PROFILE
 - AWS_CONFIG_FILE
+- TEST_ENV=${TEST_ENVIRONMENT_VARIABLE}
 image: whalebrew/awscli
 volumes:
 - ~/.aws:/.aws
 required_version: ">=0.1.0"
+mount_missing_volumes: true

--- a/run/docker.go
+++ b/run/docker.go
@@ -1,0 +1,90 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+
+	"github.com/whalebrew/whalebrew/packages"
+)
+
+// Docker implements the Runner interface
+type Docker struct {
+	Path string
+	Exec func(argv0 string, argv []string, envv []string) (err error)
+}
+
+// NewDocker creates a new default Docker runner
+func NewDocker() (*Docker, error) {
+	dockerPath, err := exec.LookPath("docker")
+	if err != nil {
+		return nil, err
+	}
+	return &Docker{
+		Path: dockerPath,
+		Exec: syscall.Exec,
+	}, nil
+}
+
+// Run runs a given package until completion
+func (d *Docker) Run(p *packages.Package, e *Execution) error {
+	if p == nil {
+		return fmt.Errorf("No package provided")
+	}
+	if p.Image == "" {
+		return fmt.Errorf("Provided package does not contain any image")
+	}
+	if e == nil {
+		return fmt.Errorf("No execution provided")
+	}
+	dockerArgs := []string{
+		d.Path,
+		"run",
+		"--interactive",
+		"--rm",
+		"--workdir", e.WorkingDir,
+		"--init",
+	}
+	args := e.Args
+	if p.Entrypoint != nil {
+		if len(p.Entrypoint) > 0 {
+			dockerArgs = append(dockerArgs, "--entrypoint", p.Entrypoint[0])
+			if len(p.Entrypoint) > 1 {
+				args = append(p.Entrypoint[1:], args...)
+			}
+		}
+	}
+	for _, portmap := range p.Ports {
+		dockerArgs = append(dockerArgs, "-p")
+		dockerArgs = append(dockerArgs, portmap)
+	}
+
+	for _, network := range p.Networks {
+		dockerArgs = append(dockerArgs, "--net")
+		dockerArgs = append(dockerArgs, network)
+	}
+	if e.IsTTYOpened {
+		dockerArgs = append(dockerArgs, "--tty")
+	}
+	for _, envvar := range e.Environment {
+		dockerArgs = append(dockerArgs, "-e")
+		dockerArgs = append(dockerArgs, envvar)
+	}
+	for _, volume := range e.Volumes {
+		dockerArgs = append(dockerArgs, "-v")
+		dockerArgs = append(dockerArgs, volume)
+	}
+	if !p.KeepContainerUser {
+		if e.User != nil {
+			dockerArgs = append(dockerArgs, "-u")
+			dockerArgs = append(dockerArgs, e.User.Uid+":"+e.User.Gid)
+		}
+	}
+	dockerArgs = append(dockerArgs, p.Image)
+	dockerArgs = append(dockerArgs, args...)
+	if d.Exec == nil {
+		return fmt.Errorf("No docker executable provided")
+	}
+	return d.Exec(d.Path, dockerArgs, os.Environ())
+}

--- a/run/docker_test.go
+++ b/run/docker_test.go
@@ -1,0 +1,101 @@
+package run_test
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/whalebrew/whalebrew/run"
+
+	"github.com/whalebrew/whalebrew/packages"
+)
+
+func TestDockerRun(t *testing.T) {
+	d := run.Docker{
+		Path: "docker",
+		Exec: nil,
+	}
+	assert.Error(t, d.Run(nil, nil))
+	assert.Error(t, d.Run(&packages.Package{}, nil))
+	assert.Error(t, d.Run(&packages.Package{
+		Image: "alpine",
+	}, nil))
+	assert.Error(t, d.Run(&packages.Package{
+		Image: "alpine",
+	}, &run.Execution{}))
+	d.Exec = func(argv0 string, argv []string, envv []string) (err error) { return errors.New("test error") }
+	assert.Error(t, d.Run(&packages.Package{
+		Image: "alpine",
+	}, &run.Execution{}))
+	d.Exec = func(argv0 string, argv []string, envv []string) (err error) { return nil }
+	assert.NoError(t, d.Run(&packages.Package{
+		Image: "alpine",
+	}, &run.Execution{}))
+
+	d.Exec = func(argv0 string, argv []string, envv []string) (err error) {
+		assert.Equal(t, "docker", argv0)
+		assert.Equal(
+			t,
+			[]string{
+				"docker", "run", "--interactive", "--rm",
+				"--workdir", "/workdir", "--init",
+				"--entrypoint", "sh",
+				"-p", "8080:8080", "-p", "1024:1024",
+				"--net", "default",
+				"--tty",
+				"-e", "HELLO=world", "-e", "world",
+				"-v", "/tmp:/tmp", "-v", "/var/run/docker.sock:/var/run/docker.sock",
+				"-u", "2048:4086",
+				"alpine",
+				"-c",
+				"-h", "hello", "world",
+			},
+			argv,
+		)
+		assert.Equal(t, os.Environ(), envv)
+		return nil
+	}
+	assert.NoError(t, d.Run(&packages.Package{
+		Image:      "alpine",
+		Ports:      []string{"8080:8080", "1024:1024"},
+		Networks:   []string{"default"},
+		Entrypoint: []string{"sh", "-c"},
+	}, &run.Execution{
+		IsTTYOpened: true,
+		WorkingDir:  "/workdir",
+		Environment: []string{"HELLO=world", "world"},
+		Volumes:     []string{"/tmp:/tmp", "/var/run/docker.sock:/var/run/docker.sock"},
+		User: &user.User{
+			Uid: "2048",
+			Gid: "4086",
+		},
+		Args: []string{"-h", "hello", "world"},
+	}))
+
+	d.Exec = func(argv0 string, argv []string, envv []string) (err error) {
+		assert.Equal(t, "docker", argv0)
+		assert.Equal(
+			t,
+			[]string{
+				"docker", "run", "--interactive", "--rm",
+				"--workdir", "/workdir", "--init",
+				"alpine",
+			},
+			argv,
+		)
+		assert.Equal(t, os.Environ(), envv)
+		return nil
+	}
+	assert.NoError(t, d.Run(&packages.Package{
+		Image:             "alpine",
+		KeepContainerUser: true,
+	}, &run.Execution{
+		WorkingDir: "/workdir",
+		User: &user.User{
+			Uid: "2048",
+			Gid: "4086",
+		},
+	}))
+}

--- a/run/interface.go
+++ b/run/interface.go
@@ -1,0 +1,22 @@
+package run
+
+import (
+	"os/user"
+
+	"github.com/whalebrew/whalebrew/packages"
+)
+
+// Execution defunes elements that depends on the current runtime request
+type Execution struct {
+	Environment []string
+	IsTTYOpened bool
+	Args        []string
+	User        *user.User
+	WorkingDir  string
+	Volumes     []string
+}
+
+// Runner must run until compoletion and return an error wether something failed
+type Runner interface {
+	Run(p *packages.Package, e *Execution) error
+}


### PR DESCRIPTION
Splitting the logic between extraction of current execution settings and actual runtime calls
This allows better testability as well as separation of concerns.
It also allows to have different implementations of the pure run interface allowing to support different runtimes whenever.