### PR TITLE
cmd/list: Control header output

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -11,10 +11,10 @@ import (
 	"github.com/whalebrew/whalebrew/packages"
 )
 
-var displayHeaders bool
+var hideHeaders bool
 
 func init() {
-	listCommand.Flags().BoolVarP(&displayHeaders, "display-headers", "", true, "Display column headers for output. Defaults to true.")
+	listCommand.Flags().BoolVarP(&hideHeaders, "no-headers", "", false, "Hide column headers for output. Defaults to false.")
 
 	RootCmd.AddCommand(listCommand)
 }
@@ -36,7 +36,7 @@ var listCommand = &cobra.Command{
 		sort.Strings(packageNames)
 
 		w := tabwriter.NewWriter(os.Stdout, 10, 2, 2, ' ', 0)
-		if displayHeaders {
+		if !hideHeaders {
 			fmt.Fprintln(w, "COMMAND\tIMAGE")
 		}
 		for _, name := range packageNames {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,12 +6,16 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/whalebrew/whalebrew/packages"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/whalebrew/whalebrew/packages"
 )
 
+var displayHeaders bool
+
 func init() {
+	listCommand.Flags().BoolVarP(&displayHeaders, "display-headers", "", true, "Display column headers for output. Defaults to true.")
+
 	RootCmd.AddCommand(listCommand)
 }
 
@@ -32,7 +36,9 @@ var listCommand = &cobra.Command{
 		sort.Strings(packageNames)
 
 		w := tabwriter.NewWriter(os.Stdout, 10, 2, 2, ' ', 0)
-		fmt.Fprintln(w, "COMMAND\tIMAGE")
+		if displayHeaders {
+			fmt.Fprintln(w, "COMMAND\tIMAGE")
+		}
 		for _, name := range packageNames {
 			fmt.Fprintf(w, "%s\t%s\n", name, packages[name].Image)
 		}


### PR DESCRIPTION
Updates the `list` command to allow controlling the output of the table
header which is useful for automated CLI interactions and scripts.