### PR TITLE
Removal of the prompt for the uninstall cmd

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -4,13 +4,18 @@ import (
 	"fmt"
 	"path"
 
+        "github.com/Songmu/prompter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/whalebrew/whalebrew/hooks"
 	"github.com/whalebrew/whalebrew/packages"
 )
 
+var forceUninstall bool
+
 func init() {
+	uninstallCommand.Flags().BoolVarP(&assumeYes, "assume-yes", "y", false, "Assume 'yes' as answer to all prompts and run non-interactively. Defaults to false.")
+
 	RootCmd.AddCommand(uninstallCommand)
 }
 
@@ -32,6 +37,12 @@ var uninstallCommand = &cobra.Command{
 
 		if err := hooks.Run("pre-uninstall", packageName); err != nil {
 			return fmt.Errorf("pre-uninstall install script failed: %s", err.Error())
+		}
+		
+                if !assumeYes {
+                	if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
+				return nil
+			}
 		}
 
 		err := pm.Uninstall(packageName)

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -35,10 +35,6 @@ var uninstallCommand = &cobra.Command{
 			return fmt.Errorf("pre-uninstall install script failed: %s", err.Error())
 		}
 
-		if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
-			return nil
-		}
-
 		err := pm.Uninstall(packageName)
 		if err != nil {
 			return err

--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/Songmu/prompter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/whalebrew/whalebrew/hooks"


### PR DESCRIPTION
Homebrew does not have a guard for uninstalling packages and neither should this package.

I rebuild the package locally and achieved the desired result.

```
whalebrew ❯ go build                                                                                                                                                                                 master
go: downloading github.com/spf13/viper v1.3.2
go: downloading github.com/spf13/cobra v0.0.4-0.20190321000552-67fc4837d267
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/google/go-cmp v0.3.0
go: downloading github.com/docker/docker v0.7.3-0.20190409075915-9d850cbfa5e9
go: downloading golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5
go: downloading github.com/spf13/pflag v1.0.3
go: downloading github.com/blang/semver v3.5.1+incompatible
go: downloading github.com/Songmu/prompter v0.0.0-20181014095714-d227c68538bd
go: downloading github.com/magiconair/properties v1.8.0
go: downloading github.com/hashicorp/hcl v1.0.0
go: downloading github.com/spf13/jwalterweatherman v1.0.0
go: downloading github.com/fsnotify/fsnotify v1.4.7
go: downloading github.com/mattn/go-isatty v0.0.7
go: downloading github.com/mitchellh/mapstructure v1.1.2
go: downloading github.com/pelletier/go-toml v1.2.0
go: downloading github.com/spf13/afero v1.1.2
go: downloading github.com/spf13/cast v1.3.0
go: downloading golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e
go: downloading golang.org/x/text v0.3.0
go: downloading github.com/docker/go-connections v0.4.0
go: downloading github.com/docker/go-units v0.3.3
go: downloading github.com/opencontainers/image-spec v1.0.1
go: downloading github.com/sirupsen/logrus v1.4.1
go: downloading github.com/docker/distribution v2.7.1+incompatible
go: downloading google.golang.org/grpc v1.19.1
go: downloading github.com/gogo/protobuf v1.2.1
go: downloading github.com/opencontainers/go-digest v1.0.0-rc1
go: downloading github.com/pkg/errors v0.8.1
go: downloading golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
go: downloading github.com/golang/protobuf v1.2.0
go: downloading google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8

whalebrew ❯ ./whalebrew install whalebrew/terraform                                                                                                                                                  master
🐳  Installed whalebrew/terraform to /usr/local/bin/terraform

whalebrew ❯ ./whalebrew list                                                                                                                                                                         master
COMMAND         IMAGE
terraform       whalebrew/terraform

whalebrew ❯ ./whalebrew uninstall terraform                                                                                                                                                          master
🚽  Uninstalled /usr/local/bin/terraform
```

