### PR TITLE
Add support for multiple search repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,31 @@ Whalebrew is configured with environment variables, which you can either provide
  - `WHALEBREW_INSTALL_PATH`: The directory to install packages in. (default: `/usr/local/bin`)
  - `WHALEBREW_CONFIG_DIR`: The directory to store configuration in. (default: `~/.whalebrew`)
 
+### Using custom registries
+
+:warning: This feature is currently under development. Any feedback or subjection is wram welcomed
+
+Whalebrew now supports handling several registries, used when searching for packages.
+
+Each reporisoty will be searched sequentially and output whalebrew packages, one per line.
+
+To enable this feature, ensure you have a configuration file in `${WHALEBREW_CONFIG_DIR:-~/.whalebrew}/config.yaml`.
+
+You can configure such running:
+
+```
+mkdir -p ${WHALEBREW_CONFIG_DIR:-~/.whalebrew}
+cat > ${WHALEBREW_CONFIG_DIR:-~/.whalebrew}/config.yaml <<EOF
+registries:
+- dockerHub:
+    owner: whalebrew
+- dockerHub:
+    owner: my-org
+EOF
+```
+
+:warning: _Note_ that if you provide a single docker hub owner, only this owner will be searched for registries, replacing the default `whalebrew` docker hub organisation.
+
 ## How it works
 
 Whalebrew is simple, and leans as much as possible on native Docker features:

--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v2"
+)
+
+type DockerHubRegistry struct {
+	Owner string `yaml:"owner"`
+}
+
+type Registry struct {
+	DockerHub *DockerHubRegistry `yaml:"dockerHub"`
+}
+
+type Config struct {
+	Registries []Registry `yaml:"registries"`
+}
+
+func GetConfig() Config {
+	configPath := filepath.Join(viper.GetString("config_dir"), "config.yaml")
+	fd, err := os.Open(configPath)
+	c := Config{}
+	if err == nil {
+		defer fd.Close()
+		yaml.NewDecoder(fd).Decode(&c)
+	}
+	if len(c.Registries) == 0 {
+		c.Registries = []Registry{{DockerHub: &DockerHubRegistry{Owner: "whalebrew"}}}
+	}
+	return c
+}


### PR DESCRIPTION

Up until now, whalebrew restricts its searches to https://hub.docker.com/u/whalebrew

This commit introduces the ability to customize search organization under docker hub.
    
To customize it, place a file like

```
repositories:
- url: https://hub.docker.com
  owner: whalebrew
```

You can add as many search repositories as desired, all of them will be searched.

Currently, there is no authentication to the search repositories. Only public images will be retrieved.

A step forward for whaleebrew tap discussed in #102