### PR TITLE
Don't run as TTY when stdout is not a TTY

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -131,7 +131,7 @@ func Run(loader packages.Loader, runner run.Runner, args []string) error {
 	return runner.Run(pkg, &run.Execution{
 		WorkingDir:  os.ExpandEnv(pkg.WorkingDir),
 		User:        user,
-		IsTTYOpened: terminal.IsTerminal(int(os.Stdin.Fd())),
+		IsTTYOpened: terminal.IsTerminal(int(os.Stdin.Fd())) && terminal.IsTerminal(int(os.Stdout.Fd())),
 		Args:        args,
 		Environment: expandEnvVars(pkg.Environment),
 		Volumes:     append(volumes, parseRuntimeVolumes(args, pkg)...),


### PR DESCRIPTION
As raised in #134, in case of piping whalebrew to a non-tty host native
program, if the original stdin is a TTY, the "whalebrewed" program may
consider being run in a TTY environment and hence send control
characters.

This is the case for `aws logs describe-log-groups` for example.

In the current version of whalebrew, running `aws logs
describe-log-groups | less` (given that less is not running on
whalebrew) results in control characters injected and hence jq to fail
parsing the output json. as described in this stackoverflow discussion
https://stackoverflow.com/questions/65824304/aws-cli-returns-json-with-control-codes-making-jq-fail

This problem can be easily solved by setting the TTY flag only when both
input and output are TTYs.

The case could still happen if the final less is also "whalebrewed"

Running the same `aws logs describe-log-groups | less` would then
trigger 2 containers. Stdout of the first one, being a pipe, will
have the `aws` command to be run without the TTY flag, fixing the
problem.

Stdin of the second one will also be a pipe, making the current
condition on stdin to run the `less` command without the TTY flag,
which does not introduce any regression compared to the current
behavior.

It does not look supported by `docker run` have a different TTY condition on
stdin and stdout that would solve the problem.

fixes: #134