### PR TITLE
Detect package or image name in uninstall

### DIFF
--- a/cmd/uninstall.go
+++ b/cmd/uninstall.go
@@ -2,9 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path"
 
-        "github.com/Songmu/prompter"
+	"github.com/Songmu/prompter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/whalebrew/whalebrew/hooks"
@@ -19,8 +20,20 @@ func init() {
 	RootCmd.AddCommand(uninstallCommand)
 }
 
+type deleteReason string
+
+var (
+	deleteReasonPackageNameMatches  deleteReason = "package name matches"
+	deleteReasonPackageImageMatches deleteReason = "package image matches"
+)
+
+type deletionCandidate struct {
+	pkg    *packages.Package
+	reason deleteReason
+}
+
 var uninstallCommand = &cobra.Command{
-	Use:   "uninstall PACKAGENAME",
+	Use:   "uninstall PACKAGENAME|IMAGENAME",
 	Short: "Uninstall a package",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
@@ -31,26 +44,55 @@ var uninstallCommand = &cobra.Command{
 		}
 
 		pm := packages.NewPackageManager(viper.GetString("install_path"))
-		packageName := args[0]
+		packageNameOrImage := args[0]
 
-		path := path.Join(pm.InstallPath, packageName)
-
-		if err := hooks.Run("pre-uninstall", packageName); err != nil {
+		if err := hooks.Run("pre-uninstall", packageNameOrImage); err != nil {
 			return fmt.Errorf("pre-uninstall install script failed: %s", err.Error())
 		}
-		
-                if !assumeYes {
-                	if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
+		packages, err := pm.List()
+		if err != nil {
+			return fmt.Errorf("unable to list packages: %v", err)
+		}
+
+		candidates := []deletionCandidate{}
+		for _, pkg := range packages {
+			if pkg.Name == packageNameOrImage {
+				candidates = append(candidates, deletionCandidate{
+					pkg:    pkg,
+					reason: deleteReasonPackageNameMatches,
+				})
+			} else if pkg.Image == packageNameOrImage {
+				candidates = append(candidates, deletionCandidate{
+					pkg:    pkg,
+					reason: deleteReasonPackageImageMatches,
+				})
+			}
+		}
+		if len(candidates) > 1 {
+			fmt.Fprintln(os.Stderr, "Many mathcing packages found. Run:")
+			for _, candidate := range candidates {
+				fmt.Fprintln(os.Stderr, "'whalebrew uninstall ", candidate.pkg.Name, "' to uninstall image ", candidate.pkg.Image)
+			}
+			os.Exit(1)
+		}
+		if len(candidates) == 0 {
+			fmt.Fprintf(os.Stderr, "Unable to find a package with name or image %s\n", packageNameOrImage)
+			return nil
+		}
+
+		path := path.Join(pm.InstallPath, candidates[0].pkg.Name)
+		if !assumeYes {
+			if !prompter.YN(fmt.Sprintf("This will permanently delete '%s'. Are you sure?", path), false) {
 				return nil
 			}
 		}
 
-		err := pm.Uninstall(packageName)
+		err = pm.Uninstall(packageNameOrImage)
 		if err != nil {
 			return err
 		}
 
-		if err := hooks.Run("post-uninstall", packageName); err != nil {
+		if err := hooks.Run("post-uninstall", packageNameOrImage); err != nil {
 			return fmt.Errorf("post-uninstall install script failed: %s", err.Error())
 		}
 		fmt.Printf("🚽  Uninstalled %s\n", path)

--- a/packages/manager.go
+++ b/packages/manager.go
@@ -17,6 +17,18 @@ type PackageManager struct {
 	InstallPath string
 }
 
+type MatchReason string
+
+const (
+	MatchReasonPackageNameMatches  MatchReason = "package name matches"
+	MatchReasonPackageImageMatches MatchReason = "package image matches"
+)
+
+type MatchingPackage struct {
+	Package
+	Reason MatchReason
+}
+
 // NewPackageManager creates a new PackageManager
 func NewPackageManager(path string) *PackageManager {
 	return &PackageManager{InstallPath: path}
@@ -163,4 +175,30 @@ func IsPackage(path string) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func (pm *PackageManager) FindByNameOrImage(packageNameOrImage string) ([]MatchingPackage, error) {
+	packages, err := pm.List()
+	if err != nil {
+		return nil, fmt.Errorf("unable to list packages: %v", err)
+	}
+
+	matchingPackages := []MatchingPackage{}
+	for _, pkg := range packages {
+		if pkg == nil {
+			continue
+		}
+		if pkg.Name == packageNameOrImage {
+			matchingPackages = append(matchingPackages, MatchingPackage{
+				Package: *pkg,
+				Reason:  MatchReasonPackageNameMatches,
+			})
+		} else if pkg.Image == packageNameOrImage {
+			matchingPackages = append(matchingPackages, MatchingPackage{
+				Package: *pkg,
+				Reason:  MatchReasonPackageImageMatches,
+			})
+		}
+	}
+	return matchingPackages, nil
 }

--- a/packages/package.go
+++ b/packages/package.go
@@ -43,7 +43,6 @@ type Package struct {
 	RequiredVersion     string   `yaml:"required_version,omitempty" labels:"required_version"`
 	PathArguments       []string `yaml:"path_arguments,omitempty" labels:"config.volumes_from_args"`
 }
-
 type StrictError interface {
 	Strict() bool
 }


### PR DESCRIPTION
While the install commands accepts an image name, the uninstall command
expects the package name.
This is confusing for users as the command is not symetrical.

Implement a simple detection mechanism that allows to detect the
relevant package to be deleted so the uninstall command can be used
using the image name as the install endpoint accepts. The previous
behaviour to be able to uninstall a package from its name is kept

fixes #162
<details>
<summary>
Committer details
</summary>
Local-Branch: master
</details>