### PR TITLE
Move default installation to /opt/whalebrew/bin on mac arm64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+* Changed the default installation path on Darwin arm64 to /opt/whalebrew/bin
+
 ### Added
 
 * Support for podman (#235)

--- a/config/config_internal_arm64_darwin_test.go
+++ b/config/config_internal_arm64_darwin_test.go
@@ -1,0 +1,13 @@
+//go:build darwin && arm64
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultInstallDirWithMacOSARM64(t *testing.T) {
+	assert.Equal(t, "/opt/whalebrew/bin", defaultInstallDir())
+}

--- a/config/config_internal_other_platforms_test.go
+++ b/config/config_internal_other_platforms_test.go
@@ -1,0 +1,13 @@
+//go:build !darwin || !arm64
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultInstallDirWithNotMacOSARM64(t *testing.T) {
+	assert.Equal(t, "/usr/local/bin", defaultInstallDir())
+}

--- a/config/config_internal_test.go
+++ b/config/config_internal_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func DefaultInstallDir() string {
+	return defaultInstallDir()
+}
+
 func TestXDGPaths(t *testing.T) {
 	t.Run("With no specific environment variable", func(t *testing.T) {
 		t.Setenv("XDG_CONFIG_HOME", "")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -90,7 +90,7 @@ func TestGetConfig(t *testing.T) {
 		t.Run("When the config file does not exist", func(t *testing.T) {
 			config.Reset()
 			require.NoError(t, os.RemoveAll(".test-resources"))
-			assert.Equal(t, "/usr/local/bin", config.GetConfig().InstallPath)
+			assert.Equal(t, config.DefaultInstallDir(), config.GetConfig().InstallPath)
 		})
 
 		t.Run("When the config file exists", func(t *testing.T) {


### PR DESCRIPTION
Follow the path drawn by homebrew and use a dedicated path on arm64 with mac os: https://github.com/Homebrew/brew/blob/b855a9eae8b7daf5fa7fbe4acc111c57024c2307/docs/FAQ.md#why-is-the-default-installation-prefix-opthomebrew-on-apple-silicon

This creates an additional requirement where users will need to manually create this path for the moment.

This will be addressed in different PR to come

fixes: #191
Change-Id: Ida3629f985608680abad2402d5f9c20a2dd7835c