### PR TITLE
Add a warning when installDir is not in PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Support for podman (#235)
 * Support for file-based configuration
+* Warn when the installed command is not available (pointing to another file or not in PATH)
 
 ### Updates
 


### PR DESCRIPTION
As we have moved, on darwin arm64, the default installation path outside from the relatively standard /usr/local/bin that was also used by homebrew, it is likely that the installation directory is not included in the PATH lookup and hence breaks the installation for several users.

Detect this situation and invite the users to take action and add the installPath in their PATH

Change-Id: I1ff03150f253ef998ce9f04c2f2d35552b1d6629