### PR TITLE
Automatically try to create installation path if it does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Support for podman (#235)
 * Support for file-based configuration
 * Warn when the installed command is not available (pointing to another file or not in PATH)
+* Automatically try to create installation path if it does not exist
 
 ### Updates
 


### PR DESCRIPTION
As we have moved, on darwin arm64, the default installation path outside from the relatively standard /usr/local/bin that was also used by homebrew, it is likely that the installation directory does not exist.

When this is the case, try to create it and fallback using sudo as `/opt` is owned by root on darwin arm64, preventing any user to create sub-folders there.

Change-Id: Ide5b46c060d99cd9a424d63fc2ef98938a079292